### PR TITLE
Add html_body rendering method.

### DIFF
--- a/src/app/main.zig
+++ b/src/app/main.zig
@@ -132,6 +132,7 @@ const Flags = struct {
         console: RenderCmdOpts,
         range: RenderCmdOpts,
         html: RenderCmdOpts,
+        html_body: RenderCmdOpts,
         format: RenderCmdOpts,
 
         serve: ServeCmdOpts,
@@ -147,6 +148,7 @@ const Flags = struct {
         pub const descriptions = .{
             .console = "Render a document as console output (ANSI escaped text)",
             .html = "Render a document to HTML",
+            .html_body = "Render a document to a html (Excluding header, css etc.)",
             .format = "Format the document (to stdout, or to given output file)",
             .serve = "Serve up documents from a directory to a localhost HTTP server",
             .present = "Present a set of Markdown files as an in-terminal presentation",
@@ -186,10 +188,11 @@ pub fn main() !void {
 
     // Process the command-line arguments
     switch (result.command) {
-        .console, .html, .format, .range => |r_opts| {
+        .console, .html, .html_body, .format, .range => |r_opts| {
             const method: zd.render.RenderMethod = switch (result.command) {
                 .console => .console,
                 .html => .html,
+                .html_body => .html_body,
                 .format => .format,
                 .range => .range,
                 else => unreachable,

--- a/src/app/serve/markdown.zig
+++ b/src/app/serve/markdown.zig
@@ -93,7 +93,7 @@ fn renderMarkdownImpl(path: []const u8) ?[]const u8 {
     var alloc_writer = std.Io.Writer.Allocating.init(alloc);
 
     // Render slide
-    var h_renderer = zd.HtmlRenderer.init(&alloc_writer.writer, alloc);
+    var h_renderer = zd.HtmlRenderer.init(&alloc_writer.writer, true, alloc);
     defer h_renderer.deinit();
     h_renderer.css = css;
 

--- a/src/lib/render.zig
+++ b/src/lib/render.zig
@@ -15,6 +15,7 @@ pub const RangeRenderer = @import("render/render_range.zig").RangeRenderer;
 pub const RenderMethod = enum(u8) {
     console,
     html,
+    html_body,
     range,
     format,
 };
@@ -36,7 +37,12 @@ pub fn render(opts: RenderOptions) !void {
 
     switch (opts.method) {
         .html => {
-            var h_renderer = HtmlRenderer.init(opts.out_stream, arena.allocator());
+            var h_renderer = HtmlRenderer.init(opts.out_stream, true, arena.allocator());
+            defer h_renderer.deinit();
+            try h_renderer.renderBlock(opts.document);
+        },
+        .html_body => {
+            var h_renderer = HtmlRenderer.init(opts.out_stream, false, arena.allocator());
             defer h_renderer.deinit();
             try h_renderer.renderBlock(opts.document);
         },

--- a/src/lib/render/render_html.zig
+++ b/src/lib/render/render_html.zig
@@ -36,6 +36,7 @@ pub const HtmlRenderer = struct {
     const RenderError = Allocator.Error || Block.Error;
     stream: Writer,
     alloc: Allocator,
+    renderFullPage: bool,
     root: ?Block = null,
     css: Css = .{},
     /// Optional HTML to be inserted at the start of the <body> tag
@@ -44,13 +45,14 @@ pub const HtmlRenderer = struct {
     footer: []const u8 = "",
 
     /// Create a new HtmlRenderer
-    pub fn init(stream: Writer, alloc: Allocator) Self {
+    pub fn init(stream: Writer, renderFullPage: bool, alloc: Allocator) Self {
         if (!wasm.is_wasm) {
             ts_queries.init(alloc);
         }
         return HtmlRenderer{
             .stream = stream,
             .alloc = alloc,
+            .renderFullPage = renderFullPage,
         };
     }
 
@@ -151,14 +153,14 @@ pub const HtmlRenderer = struct {
 
     /// Render a Document block (contains only other blocks)
     fn renderDocument(self: *Self, doc: Container) !void {
-        self.renderBegin();
+        if (self.renderFullPage) self.renderBegin();
         for (doc.children.items) |block| {
             try self.renderBlock(block);
             // if (!isBreak(&block)) {
             //     try self.renderBreak();
             // }
         }
-        self.renderEnd();
+        if (self.renderFullPage) self.renderEnd();
     }
 
     /// Render a Quote block


### PR DESCRIPTION
This allows one to use the html renderer for ones own template without having to bypass the proper rendering code path.
In my project this would change this code:
```C
          var parser = zigdown.Parser.init(r, .{ .verbose = false });
            defer parser.deinit();
            try parser.parseMarkdown(data);

            var arena = std.heap.ArenaAllocator.init(r);
            defer arena.deinit();
            const a_r = arena.allocator();

            var writer = std.io.Writer.Allocating.init(r);
            var renderer = zigdown.HtmlRenderer.init(&writer.writer, a_r);
            defer renderer.deinit();
            for (parser.document.container().children.items) |child| {
                try renderer.renderBlock(child);
            }

            const output_data = try writer.toOwnedSlice();
            return output_data;
```

to 
```C
            var parser = zigdown.Parser.init(r, .{ .verbose = false });
            defer parser.deinit();
            try parser.parseMarkdown(data);

            var arena = std.heap.ArenaAllocator.init(r);
            defer arena.deinit();
            const a_r = arena.allocator();

            var writer = std.io.Writer.Allocating.init(r);
            zigdown.render.render(.{
                .document = parser.document,
                .alloc = a_r,
                .method = .html_body,
                .out_stream = writer,
            });

            const output_data = try writer.toOwnedSlice();
            return output_data;
```

Which eliminates the use to directly interact with the HTMLRenderer.
This is an opinionated change, and I could understand if it is outside of the scope, as it is already possible with the method I showed in the first code block.
The name 'html_body' was my first idea, couldn't come up with a better one, if you can suggest a better Name I am open to that.

As zig does to my knowledge not support overloads, this is a breaking change for any other project that inits the HTMLRenderer, as there was boolean added the function parameters.

Thanks for the amazing library :> 